### PR TITLE
Fix error handling in mutexify

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ class Hyperdiscovery extends EventEmitter {
       self._lock(release => {
         _add(dkey)
           .then(() => release())
-          .catch(err => release(err))
+          .catch(err => release(null, err))
       })
     }
 


### PR DESCRIPTION
The release function [expects a function](https://github.com/mafintosh/mutexify/blob/master/index.js#L19) as it's first argument. So when there's an error it creates an unhandled rejected promise.