### PR TITLE
Added option to specify extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,8 @@ class Hyperdiscovery extends EventEmitter {
     var stream = hypercoreProtocol({
       id: this.id,
       live: true,
-      encrypt: true
+      encrypt: true,
+      extensions: this._opts.extensions
     })
     stream.peerInfo = info
 


### PR DESCRIPTION
I'm working on an implementation of [the datPeers](https://github.com/RangerMauve/dat-peers) API for people to reuse, and it requires specifying extensions to the hypercore protocol.

I think that down the line people might want to use different extensions with hyperdiscovery, so this'll make it easier for them to use.