### PR TITLE
Web support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 package-lock.json
+
+example-bundle.js

--- a/example.html
+++ b/example.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<title>hyperdiscovery example</title>
+<script src="example-bundle.js"></script>
+<h1>Open dev tools to see output</h1>

--- a/example.js
+++ b/example.js
@@ -1,4 +1,3 @@
-var fs = require('fs')
 var hyperdrive = require('hyperdrive')
 var ram = require('random-access-memory')
 var Discovery = require('.')
@@ -13,9 +12,11 @@ archive.ready(function (err) {
   console.log('key', archive.key.toString('hex'))
 })
 
+const toWrite = 'console.log("Hello World!")'
+
 archive2.ready(function (err) {
   if (err) throw err
-  archive2.writeFile('example.js', fs.readFileSync('example.js'), () => {})
+  archive2.writeFile('example.js', toWrite, () => {})
   discovery.add(archive2)
   console.log('key', archive2.key.toString('hex'))
 })

--- a/index.js
+++ b/index.js
@@ -49,11 +49,17 @@ class Hyperdiscovery extends EventEmitter {
     }
 
     this._swarm = discoverySwarm(swarmDefaults({
-      id: this.id,
+      // Discovery-swarm options
       hash: false,
       utp: defaultTrue(opts.utp),
       tcp: defaultTrue(opts.tcp),
       dht: defaultTrue(opts.dht),
+
+      // Discovery-swarm-web options
+      signalhub: opts.signalhub,
+      discovery: opts.discovery,
+
+      id: this.id,
       stream: this._createReplicationStream.bind(this)
     }))
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Join the p2p swarm for hypercore and hyperdrive feeds.",
   "main": "index.js",
   "scripts": {
-    "test": "standard && dependency-check . && node test.js"
+    "test": "standard && dependency-check . && node test.js",
+    "build-example": "browserify example.js > example-bundle.js"
   },
   "repository": {
     "type": "git",
@@ -15,16 +16,21 @@
   "bugs": {
     "url": "https://github.com/datproject/hyperdiscovery/issues"
   },
+  "browser": {
+    "discovery-swarm": "discovery-swarm-web"
+  },
   "homepage": "https://github.com/datproject/hyperdiscovery#readme",
   "dependencies": {
     "dat-encoding": "^5.0.1",
     "dat-swarm-defaults": "^1.0.2",
     "debug": "^4.1.1",
     "discovery-swarm": "^5.1.4",
+    "discovery-swarm-web": "^1.3.0",
     "hypercore-protocol": "^6.9.0",
     "mutexify": "^1.2.0"
   },
   "devDependencies": {
+    "browserify": "^16.2.3",
     "dependency-check": "^3.3.0",
     "hypercore": "^6.25.2",
     "hyperdb": "^3.5.0",

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![build status](https://travis-ci.org/datproject/hyperdiscovery.svg?branch=master)](http://travis-ci.org/datproject/hyperdiscovery)
 
 Join the p2p swarm for [hypercore][core] and [hyperdrive][drive]. Uses
-[discovery-swarm][swarm] under the hood.
+[discovery-swarm][swarm] under the hood. Also works in web browsers using [discovery-swarm-web](https://github.com/RangerMauve/discovery-swarm-web).
 
 ```
 npm install hyperdiscovery
@@ -21,7 +21,7 @@ var Discovery = require('hyperdiscovery')
 var archive = hyperdrive('./database', 'ARCHIVE_KEY')
 var discovery = Discovery(archive)
 discovery.on('connection', function (peer, type) {
-  console.log('got', peer, type) 
+  console.log('got', peer, type)
   console.log('connected to', discovery.connections, 'peers')
   peer.on('close', function () {
     console.log('peer disconnected')
@@ -79,6 +79,8 @@ Exit the swarm, close all replication streams.
   * `port`: port for discovery swarm
   * `utp`: use utp in discovery swarm
   * `tcp`: use tcp in discovery swarm
+  * `signalhub`: string, WebRTC signalhub server for web
+  * `discovery`: string, discovery-swarm-stream server for web
 
 Defaults from datland-swarm-defaults can also be overwritten:
 
@@ -91,6 +93,7 @@ Defaults from datland-swarm-defaults can also be overwritten:
 - [mafintosh/hyperdrive][drive]
 - [mafintosh/hyperdb][db]
 - [mafintosh/discovery-swarm][swarm]
+- [discovery-swarm-web][swarm-web]
 
 ## License
 ISC
@@ -99,3 +102,4 @@ ISC
 [drive]: https://github.com/mafintosh/hyperdrive
 [db]: https://github.com/mafintosh/hyperdb
 [swarm]: https://github.com/mafintosh/discovery-swarm
+[swarm-web]: https://github.com/RangerMauve/discovery-swarm-web


### PR DESCRIPTION
Added support for discovery-swarm-web

This lets us reuse hyperdiscovery for both Node.js and browsers. I'm planning on using this as part of the SDK.