### PR TITLE
Bind random port if all alternative ports fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ class Hyperdiscovery extends EventEmitter {
       if (err && err.code !== 'EADDRINUSE' && err.message !== 'Could not bind') return this.emit('error', err)
       const port = this._portAlts.shift()
       debug(`Port ${this._port} in use. Trying ${port}.`)
+      this._port = port;
       this.listen(port)
     })
 

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ class Hyperdiscovery extends EventEmitter {
       if (err && err.code !== 'EADDRINUSE' && err.message !== 'Could not bind') return this.emit('error', err)
       const port = this._portAlts.shift()
       debug(`Port ${this._port} in use. Trying ${port}.`)
-      this._port = port;
+      this._port = port
       this.listen(port)
     })
 


### PR DESCRIPTION
If binding of all ports in the `_portAlts` list fails, we get stuck in an infinite loop trying to bind the first port number. This change updates `this._port` on every retry so at the end of the list we listen with `undefined` which will give us a random port.

Code to reproduce the original issue:
```js
const Discovery = require('hyperdiscovery');
const swarm = Discovery();
```
Then run: `DEBUG=hyperdiscovery node index.js`

Observed output:
```
 hyperdiscovery Port 3282 in use. Trying 3000.
 hyperdiscovery Port 3282 in use. Trying 3002.
 hyperdiscovery Port 3282 in use. Trying 3004.
 hyperdiscovery Port 3282 in use. Trying 2001.
 hyperdiscovery Port 3282 in use. Trying 2003.
 hyperdiscovery Port 3282 in use. Trying 2005.
 hyperdiscovery Port 3282 in use. Trying undefined.
 hyperdiscovery Port 3282 in use. Trying undefined.
...
```

After this change:
```
  hyperdiscovery Port 3282 in use. Trying 3000. +0ms
  hyperdiscovery Port 3000 in use. Trying 3002. +4ms
  hyperdiscovery Port 3002 in use. Trying 3004. +1ms
  hyperdiscovery Port 3004 in use. Trying 2001. +3ms
  hyperdiscovery Port 2001 in use. Trying 2003. +0ms
  hyperdiscovery Port 2003 in use. Trying 2005. +0ms
  hyperdiscovery Port 2005 in use. Trying undefined. +1ms
  hyperdiscovery swarm:listening { port: 62989 } +9ms
```