### PR TITLE
Allow options to be passed to discovery-swarm when adding a feed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,19 +194,19 @@ class Hyperdiscovery extends EventEmitter {
     return stream
   }
 
-  add (feed) {
+  add (feed, opts) {
     if (!feed.key) return feed.ready(() => { this.add(feed) })
     const key = datEncoding.toStr(feed.key)
     const discoveryKey = datEncoding.toStr(feed.discoveryKey)
     this._replicatingFeeds.set(discoveryKey, feed)
 
-    this.rejoin(feed.discoveryKey)
+    this.rejoin(feed.discoveryKey, opts)
     this.emit('join', { key, discoveryKey })
     feed.isSwarming = true
   }
 
-  rejoin (discoveryKey) {
-    this._swarm.join(datEncoding.toBuf(discoveryKey))
+  rejoin (discoveryKey, opts) {
+    this._swarm.join(datEncoding.toBuf(discoveryKey), opts)
   }
 
   listen (port) {

--- a/readme.md
+++ b/readme.md
@@ -63,9 +63,9 @@ var discovery = Discovery(feed)
 
 Join the p2p swarm for the given feed. The return object, `discovery`, is an event emitter that will emit a `peer` event with the peer information when a peer is found.
 
-### `discovery.add(archive)`
+### `discovery.add(archive, [opts])`
 
-Add an archive/feed to the discovery swarm.
+Add an archive/feed to the discovery swarm. Options will be passed to `discovery-swarm`. If you pass `opts.announce` as a falsy value you don't announce your port (discover-only mode).
 
 ### `discovery.totalConnections`
 


### PR DESCRIPTION
I would like to control when a device's IP and port are advertised to the network. This is supported by `discovery-swarm` with the `announce` option, but this module does not pass options through `add`. 

This PR adds an optional second argument to `add` to allow options to be pass through to `discovery-swarm`.